### PR TITLE
Update _tables.scss

### DIFF
--- a/blueberry/scss/_tables.scss
+++ b/blueberry/scss/_tables.scss
@@ -55,6 +55,12 @@ table td img {
 	height: 22px;
 }
 
+@media only screen and (min-width: 768px) {
+  .table th.position-sticky {
+    top: 81px;
+  }
+}
+
 // .table-hover {
 // 	tbody tr {
 // 		@include hover() {


### PR DESCRIPTION
minor tweak for sticky table

hai @movahhedi, i really love this theme. it is suitable for the phpmyadmin in dark mode. i prefer this theme to others official theme. but when i try to scroll large and long list of data, the header column isn't sticky. I have compared to other official theme, i think you forgot to put the position css style to make the table sticky in the right position.


https://github.com/movahhedi/blueberry-pma-theme/assets/13099373/c12949e7-9d9e-44da-9de3-56ae7c207903

